### PR TITLE
Prevent duplicate wizard drafts

### DIFF
--- a/apps/web/src/components/Header/index.tsx
+++ b/apps/web/src/components/Header/index.tsx
@@ -145,7 +145,7 @@ export default function Header({ title = siteName, versions, hideMenu, wizard }:
                   </Button>
                 ) : null}
                 {/* The user is on the draft version */}
-                {wizard?.data.draftVersion?.id === activeVersion.id && !wizard?.data.isTemplate ? (
+                {!activeVersion.publishedFrom && !wizard?.data.isTemplate ? (
                   <Button
                     size="small"
                     iconOnlyOnMobile="CloudUpload"

--- a/apps/web/src/modals/DeleteDraft.tsx
+++ b/apps/web/src/modals/DeleteDraft.tsx
@@ -26,9 +26,9 @@ export default function DeleteDraftModal() {
   const activeVersion = versions?.find((version) => version.id === match?.params.versionId)
   const deletionAllowed = Boolean(
     wizard?.data.publishedVersion &&
-    match?.params.versionId &&
-    activeVersion &&
-    !activeVersion.publishedFrom,
+      match?.params.versionId &&
+      activeVersion &&
+      !activeVersion.publishedFrom,
   )
 
   const onClose = () => setModal()

--- a/apps/web/src/modals/DeleteDraft.tsx
+++ b/apps/web/src/modals/DeleteDraft.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import Button from '@/components/Button'
 import ButtonBar from '@/components/ButtonBar'
 import Form from '@/components/Form'
@@ -15,6 +16,7 @@ export default function DeleteDraftModal() {
     match?.params.versionId,
   )
   const { modal, setModal } = useModal()
+  const [deletionInProgress, setDeletionInProgress] = useState(false)
   const navigate = useNavigate()
 
   if (modal?.key !== 'delete-draft') {
@@ -34,7 +36,10 @@ export default function DeleteDraftModal() {
     if (!match?.params.versionId || !deletionAllowed) {
       return
     }
+    // Prevent error message flickering on modal animate out
+    setDeletionInProgress(true)
 
+    // Delete the draft version
     await deleteVersion(match?.params.versionId)
 
     // Navigate to the published version of the wizard
@@ -55,7 +60,7 @@ export default function DeleteDraftModal() {
           </>
         }
       />
-      {!deletionAllowed ? (
+      {!deletionAllowed && !deletionInProgress ? (
         <Message title="Versjonen kan ikke slettes">
           Prøv å lukk nettleseren og åpne veiviseren på ny.
         </Message>

--- a/apps/web/src/modals/DeleteDraft.tsx
+++ b/apps/web/src/modals/DeleteDraft.tsx
@@ -3,13 +3,17 @@ import ButtonBar from '@/components/ButtonBar'
 import Form from '@/components/Form'
 import Help from '@/components/Help'
 import Modal from '@/components/Modal'
+import Message from '@/components/Message'
 import { useModal } from '@/hooks/useModal'
 import useWizard from '@/hooks/useWizard'
 import { useMatch, useNavigate } from 'react-router'
 
 export default function DeleteDraftModal() {
   const match = useMatch('/wizard/:wizardId/:versionId')
-  const { wizard, deleteVersion } = useWizard(match?.params.wizardId, match?.params.versionId)
+  const { wizard, versions, deleteVersion } = useWizard(
+    match?.params.wizardId,
+    match?.params.versionId,
+  )
   const { modal, setModal } = useModal()
   const navigate = useNavigate()
 
@@ -17,8 +21,13 @@ export default function DeleteDraftModal() {
     return null
   }
 
-  const deletionAllowed =
-    wizard?.data.publishedVersion && match?.params.versionId === wizard?.data.draftVersion?.id
+  const activeVersion = versions?.find((version) => version.id === match?.params.versionId)
+  const deletionAllowed = Boolean(
+    wizard?.data.publishedVersion &&
+    match?.params.versionId &&
+    activeVersion &&
+    !activeVersion.publishedFrom,
+  )
 
   const onClose = () => setModal()
   const handleDelete = async () => {
@@ -46,7 +55,11 @@ export default function DeleteDraftModal() {
           </>
         }
       />
-
+      {!deletionAllowed ? (
+        <Message title="Versjonen kan ikke slettes">
+          Prøv å lukk nettleseren og åpne veiviseren på ny.
+        </Message>
+      ) : null}
       <Form onSubmit={onClose}>
         <ButtonBar>
           <Button type="button" disabled={!deletionAllowed} onClick={handleDelete} warning>

--- a/apps/web/src/modals/Draft.tsx
+++ b/apps/web/src/modals/Draft.tsx
@@ -4,6 +4,7 @@ import Dropdown from '@/components/Dropdown'
 import Form from '@/components/Form'
 import Modal from '@/components/Modal'
 import Help from '@/components/Help'
+import Message from '@/components/Message'
 import { useModal } from '@/hooks/useModal'
 import { useVersion } from '@/hooks/useVersion'
 import useWizard from '@/hooks/useWizard'
@@ -19,12 +20,17 @@ export default function DraftModal() {
   const { createDraftVersion } = useVersion()
   const [baseOn, setBaseOn] = useState<string>()
   const navigate = useNavigate()
+  const hasUnpublishedDraft = versions?.some((version) => !version.publishedFrom) ?? false
 
   if (modal?.key !== 'draft' || loading) {
     return null
   }
 
   const handlePublish = async () => {
+    if (!baseOn || hasUnpublishedDraft) {
+      return
+    }
+
     const draftVersionId = await createDraftVersion(baseOn === 'from-scratch' ? undefined : baseOn)
     onClose()
     navigate(`/wizard/${match?.params.wizardId}/${draftVersionId}`)
@@ -58,9 +64,18 @@ export default function DraftModal() {
               },
             ]}
           />
-
+          {hasUnpublishedDraft && (
+            <Message title="Du har allerede et utkast">
+              <p>Publiser eller slett det eksisterende utkastet før du lager et nytt.</p>
+            </Message>
+          )}
           <ButtonBar margins>
-            <Button type="button" primary onClick={handlePublish} disabled={!baseOn}>
+            <Button
+              type="button"
+              primary
+              onClick={handlePublish}
+              disabled={!baseOn || hasUnpublishedDraft}
+            >
               Lag utkast
             </Button>
 

--- a/apps/web/src/modals/Draft.tsx
+++ b/apps/web/src/modals/Draft.tsx
@@ -19,6 +19,7 @@ export default function DraftModal() {
   const { modal, setModal } = useModal()
   const { createDraftVersion } = useVersion()
   const [baseOn, setBaseOn] = useState<string>()
+  const [apiError, setApiError] = useState<string>()
   const navigate = useNavigate()
   const hasUnpublishedDraft = versions?.some((version) => !version.publishedFrom) ?? false
 
@@ -31,14 +32,24 @@ export default function DraftModal() {
       return
     }
 
-    const draftVersionId = await createDraftVersion(baseOn === 'from-scratch' ? undefined : baseOn)
-    onClose()
-    navigate(`/wizard/${match?.params.wizardId}/${draftVersionId}`)
+    setApiError(undefined)
+
+    try {
+      const draftVersionId = await createDraftVersion(
+        baseOn === 'from-scratch' ? undefined : baseOn,
+      )
+      onClose()
+      navigate(`/wizard/${match?.params.wizardId}/${draftVersionId}`)
+    } catch (error) {
+      console.error('Failed to create draft version', error)
+      setApiError(error instanceof Error ? error.message : 'Ukjent feil oppstod.')
+    }
   }
 
   const onClose = () => {
     setModal()
     setBaseOn(undefined)
+    setApiError(undefined)
   }
 
   const publishedVersions = versions?.filter((v) => v.publishedFrom) || []
@@ -67,6 +78,11 @@ export default function DraftModal() {
           {hasUnpublishedDraft && (
             <Message title="Du har allerede et utkast">
               <p>Publiser eller slett det eksisterende utkastet før du lager et nytt.</p>
+            </Message>
+          )}
+          {apiError && (
+            <Message title="Kunne ikke lage utkast">
+              <p>{apiError}</p>
             </Message>
           )}
           <ButtonBar margins>

--- a/apps/web/src/services/firebase/index.ts
+++ b/apps/web/src/services/firebase/index.ts
@@ -969,6 +969,11 @@ export async function createDraftVersion(
 
   return runTransaction(db, async (transaction) => {
     const wizardRef = getWizardRef(db, wizardId)
+    const wizardSnapshot = await transaction.get(wizardRef)
+
+    if (wizardSnapshot.exists() && wizardSnapshot.data()?.draftVersion) {
+      throw new Error('Unpublished draft already exists for this wizard')
+    }
     const copyFromVersionRef = copyFromVersionId
       ? getWizardVersionRef({ db, wizardId, versionId: copyFromVersionId })
       : undefined

--- a/apps/web/src/services/firebase/index.ts
+++ b/apps/web/src/services/firebase/index.ts
@@ -970,9 +970,13 @@ export async function createDraftVersion(
   return runTransaction(db, async (transaction) => {
     const wizardRef = getWizardRef(db, wizardId)
     const wizardSnapshot = await transaction.get(wizardRef)
+    const draftVersionRef = wizardSnapshot.data()?.draftVersion as DocumentReference | undefined
 
-    if (wizardSnapshot.exists() && wizardSnapshot.data()?.draftVersion) {
-      throw new Error('Unpublished draft already exists for this wizard')
+    if (wizardSnapshot.exists() && draftVersionRef) {
+      const draftVersionSnapshot = await transaction.get(draftVersionRef)
+      if (draftVersionSnapshot.exists()) {
+        throw new Error('Unpublished draft already exists for this wizard')
+      }
     }
     const copyFromVersionRef = copyFromVersionId
       ? getWizardVersionRef({ db, wizardId, versionId: copyFromVersionId })

--- a/apps/web/src/styles/1_settings/_vars.scss
+++ b/apps/web/src/styles/1_settings/_vars.scss
@@ -5,7 +5,8 @@ $container-base: getStrippedPxSizeInRem(1220px);
 $container-width: (
     base: 1120px,
     // makeContainerSize(12),
-    tight: 560px, // makeContainerSize(5),,
+    tight: 560px,
+    // makeContainerSize(5),,
 );
 
 // Spacing

--- a/apps/web/src/styles/1_settings/_vars.scss
+++ b/apps/web/src/styles/1_settings/_vars.scss
@@ -5,8 +5,7 @@ $container-base: getStrippedPxSizeInRem(1220px);
 $container-width: (
     base: 1120px,
     // makeContainerSize(12),
-    tight: 560px,
-    // makeContainerSize(5),,
+    tight: 560px, // makeContainerSize(5),,
 );
 
 // Spacing


### PR DESCRIPTION
Siri reported an issue where [this wizard](https://veiviser.dibk.cloud/wizard/a52557a0-db1a-4ae4-b097-0283bfaffb2e/18ac7053-8317-49a7-9eab-0675ec25610a) has got multiple draft versions without the option of deleting any of them, or publishing one. 

This bug might have been caused my multiple users in the same wizard triggering new drafts with an outdated wizard version cached locally. 

This fix prevents the creation of new drafts if the wizard all ready have one (block both in UI and in the api), and makes it possible to delete stray draft versions. It also makes it possible to publish a linked draft, even though it is not considered the active draft or not. This distintion is handy, but not necessary for the functionality so this change is more open and friendly for edge cases like this. 

To fix the wizard mentioned we can now delete the stray draft versions and published the wanted version in the UI. 